### PR TITLE
 Updated domain (".io" -> ".com")

### DIFF
--- a/devRantDotNet.Tests/Tests.cs
+++ b/devRantDotNet.Tests/Tests.cs
@@ -52,7 +52,7 @@ namespace devRantDotNet.Tests
         public void GetRandomRantAsyncTest()
         {
             var result = dr.GetRandomRantAsync().Result;
-            Assert.IsTrue(result.score >= 20);
+            Assert.IsTrue(!string.IsNullOrEmpty(result.text));
         }
 
     }

--- a/devRantDotNet/Source/Resources/Values.cs
+++ b/devRantDotNet/Source/Resources/Values.cs
@@ -8,7 +8,7 @@ namespace devRantDotNet
 {
     internal static class Values
     {
-        internal const string API = "https://www.devrant.io/api";
+        internal const string API = "https://devrant.com/api";
         internal const string AppId = "app=3";
         internal const string UsernameById = API + "/get-user-id";
         internal const string AllRants = API + "/devrant/rants";


### PR DESCRIPTION
devRant doesn't use ".io" domain anymore, so it's better to use ".com" (without "www." at the beginning) to prevent useless redirects and possible future issues.